### PR TITLE
chore(tests): remove async function from describe

### DIFF
--- a/test/musquettte.test.ts
+++ b/test/musquettte.test.ts
@@ -30,7 +30,7 @@ function startBroker(
   return [port, server]
 }
 
-describe('Connect', async () => {
+describe('Connect', () => {
   let port, broker
 
   beforeEach(done => {


### PR DESCRIPTION
A describe block was returning a promise although it did not need to